### PR TITLE
fix issue when there is more than one U2F key registered

### DIFF
--- a/src/U2FServer.php
+++ b/src/U2FServer.php
@@ -196,6 +196,7 @@ class U2FServer
     public static function makeAuthentication(array $registrations, $appId)
     {
         $signatures = [];
+        $challenge = static::createChallenge();
         foreach ($registrations as $reg) {
             if( !is_object( $reg ) ) {
                 throw new \InvalidArgumentException('$registrations of makeAuthentication() method only accepts array of object.');
@@ -204,7 +205,7 @@ class U2FServer
             $signatures[] = new SignRequest([
                 'appId' => $appId,
                 'keyHandle' => $reg->keyHandle,
-                'challenge' => static::createChallenge(),
+                'challenge' => $challenge,
             ]);
         }
         return $signatures;


### PR DESCRIPTION
When a user has more than one U2F key registered to it account, it's not possible to authenticate correctly with the other keys because the challenge is different for each key, while the FIDO specifications for the JS signing function allow only to pass one challenge, even if there is multiple keys.

This simple fix use the same challenge for every keys so you can now authenicate through multiple keys.