### PR TITLE
Add ReturnTypeWillChange to JsonSerializable implementations

### DIFF
--- a/src/RegistrationRequest.php
+++ b/src/RegistrationRequest.php
@@ -44,6 +44,7 @@ class RegistrationRequest implements \JsonSerializable
         return $this->appId;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/SignRequest.php
+++ b/src/SignRequest.php
@@ -62,6 +62,7 @@ class SignRequest implements \JsonSerializable
         return $this->appId;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
This adds `#[ReturnTypeWillChange]` annotations to suppress the deprecation notice in PHP 8.1.

```
Deprecated: Declaration of Samyoul\U2F\U2FServer\RegistrationRequest::jsonSerialize() should be compatible with JsonSerializable::jsonSerialize(): mixed in vendor/samyoul/u2f-php-server/src/RegistrationRequest.php on line 47
Deprecated: Declaration of Samyoul\U2F\U2FServer\SignRequest::jsonSerialize() should be compatible with JsonSerializable::jsonSerialize(): mixed in vendor/samyoul/u2f-php-server/src/SignRequest.php on line 65
```

See: [PHP RFC: Add return type declarations for internal methods](https://wiki.php.net/rfc/internal_method_return_types)